### PR TITLE
change url to the libsass-maven-plugin

### DIFF
--- a/source/libsass.html.haml
+++ b/source/libsass.html.haml
@@ -71,7 +71,7 @@ introduction: >
 
       There is one Java wrapper --- [jsass](https://github.com/bit3/jsass).
       There is also a plugin for Maven --- [LibSass Maven
-      plugin](https://github.com/warmuuh/libsass-maven-plugin).
+      plugin](https://gitlab.com/haynes/libsass-maven-plugin).
 
   %li#javascript
     :markdown


### PR DESCRIPTION
This PR changes the url of the libsass-maven-plugin to an actively maintained fork.  
The jsass project already links to the fork as well. 😃 